### PR TITLE
fix(routes): pass correct args + xywh bbox to run_samurai_tracking (#4)

### DIFF
--- a/server/routes/analysis.py
+++ b/server/routes/analysis.py
@@ -110,12 +110,25 @@ async def start_tracking(
                      selected_bbox=s_merged["selected_bbox"],
                      start_frame=payload.frame)
 
+    # Convert the xyxy bbox the API exposes into the xywh+frame shape
+    # run_samurai_tracking expects (`player_bbox['x' | 'y' | 'w' | 'h']`
+    # plus `player_bbox.get('frame', 0)` — see server/pipeline/tasks.py).
+    # Forgetting the conversion + dropping the SessionManager arg made
+    # every track call raise TypeError (issue #4).
+    player_bbox = {
+        "x": x1,
+        "y": y1,
+        "w": x2 - x1,
+        "h": y2 - y1,
+        "frame": payload.frame,
+    }
+
     def _on_error(exc: BaseException) -> None:
         sm.update_status(session_id, "tracking_failed", error=str(exc))
 
     pool.submit_gpu(
         pipeline_tasks.run_samurai_tracking,
-        session_id, s_merged, sm, on_error=_on_error,
+        session_id, s_merged, player_bbox, sm, on_error=_on_error,
     )
     return QueuedResponse(task_id=session_id, status="tracking")
 


### PR DESCRIPTION
## Summary

\`POST /api/sessions/{id}/track\` called

\`\`\`python
pool.submit_gpu(
    pipeline_tasks.run_samurai_tracking,
    session_id, s_merged, sm, ...
)
\`\`\`

against a 4-arg function

\`\`\`python
def run_samurai_tracking(session_id, session, player_bbox, sm):
\`\`\`

…so every track request raised \`TypeError: run_samurai_tracking() missing 1 required positional argument: 'sm'\`. \`sm\` silently filled the \`player_bbox\` slot, and the real \`SessionManager\` was never supplied.

Even after fixing the count, \`run_samurai_tracking\` reads \`player_bbox['x' | 'y' | 'w' | 'h']\` (and \`.get('frame', 0)\`), but the route stored the bbox as \`{x1, y1, x2, y2}\`.

## Fix

- Build a proper \`{x, y, w, h, frame}\` dict from the \`xyxy\` payload right after the existing validation.
- Pass it as the third positional argument and add \`sm\` as the fourth, matching \`run_samurai_tracking\`'s signature.

Fixes #4

## Test plan

- [x] \`python3 -c 'import ast; ast.parse(...)'\`
- [x] Walked the new call site against \`run_samurai_tracking(session_id, session, player_bbox, sm)\` — types and arity now line up.